### PR TITLE
Fix state initialization types

### DIFF
--- a/src/pages/blobs/_components/ShapeEditor.tsx
+++ b/src/pages/blobs/_components/ShapeEditor.tsx
@@ -3,7 +3,7 @@ import NewShape from './NewShape.tsx';
 import StoredShapes from './StoredShapes.tsx';
 
 export default function ShapeEditor() {
-    const [lastMutationTime, setLastMutationTime] = useState<number>(null);
+    const [lastMutationTime, setLastMutationTime] = useState<number | null>(null);
 
     return (
         <div className="flex flex-col gap-8 md:flex-row">

--- a/src/pages/blobs/_components/StoredShapes.tsx
+++ b/src/pages/blobs/_components/StoredShapes.tsx
@@ -10,8 +10,8 @@ interface Props {
 export default function StoredShapes(props: Props) {
     const { lastMutationTime } = props;
     const [keys, setKeys] = useState<string[]>([]);
-    const [selectedKey, setSelectedKey] = useState<string>(null);
-    const [previewData, setPreviewData] = useState<BlobProps>(null);
+    const [selectedKey, setSelectedKey] = useState<string | null>(null);
+    const [previewData, setPreviewData] = useState<BlobProps | null>(null);
 
     const getBlobKeyList = async () => {
         console.log('Fetching keys...');


### PR DESCRIPTION
## Summary
- fix `useState` initial value types in blob shape components

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f42442ab0832fb1ca01eca3c015c6