### PR TITLE
Centralize API endpoints

### DIFF
--- a/public/apiConfo.js
+++ b/public/apiConfo.js
@@ -1,0 +1,6 @@
+window.apiConfig = {
+  equipmentEndpoint: '/.netlify/functions/equipment',
+  spaceEndpoint: '/.netlify/functions/space',
+  jobsEndpoint: '/.netlify/functions/jobs',
+  meldingEndpoint: '/.netlify/functions/melding'
+};

--- a/src/pages/chatbot.html
+++ b/src/pages/chatbot.html
@@ -144,6 +144,7 @@
                 }
             }
         </style>
+<script src="/apiConfo.js"></script>
     </head>
     <body>
         <header>
@@ -203,7 +204,7 @@
 
             function fetchLocationDescription() {
                 if (!id || !type) return;
-                const endpoint = type === 'eq' ? '/.netlify/functions/equipment' : '/.netlify/functions/space';
+                const endpoint = type === 'eq' ? window.apiConfig.equipmentEndpoint : window.apiConfig.spaceEndpoint;
                 fetch(`${endpoint}?id=${encodeURIComponent(id)}`)
                     .then((res) => res.json())
                     .then((data) => {
@@ -219,7 +220,7 @@
 
             async function fetchOpenJobs(type, id) {
                 try {
-                    const res = await fetch(`/.netlify/functions/jobs?type=${type}&id=${id}`);
+                    const res = await fetch(`${window.apiConfig.jobsEndpoint}?type=${type}&id=${id}`);
                     if (!res.ok) throw new Error(`Server error ${res.status}`);
                     const jobs = await res.json();
                     return Array.isArray(jobs) ? jobs : [];
@@ -363,7 +364,7 @@
                             return botui.message.add({ content: isFr ? 'Adresse e-mail invalide.' : 'Ongeldig e-mailadres.' }).then(() => askEmail());
                         }
                         const payload = { id, type, JobDescr: omschrijving, ReportText: email, lang };
-                        return fetch('/.netlify/functions/melding', {
+                        return fetch(window.apiConfig.meldingEndpoint, {
                             method: 'POST',
                             headers: { 'Content-Type': 'application/json' },
                             body: JSON.stringify(payload)

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -118,6 +118,7 @@
       margin-bottom: 3rem;
     }
   </style>
+<script src="/apiConfo.js"></script>
 </head>
 <body>
 
@@ -173,7 +174,7 @@
     // ruimte of installatie ophalen
     const label = document.getElementById("ruimteLabel");
     if (id && type) {
-      const endpoint = type === "eq" ? "/.netlify/functions/equipment" : "/.netlify/functions/space";
+      const endpoint = type === "eq" ? window.apiConfig.equipmentEndpoint : window.apiConfig.spaceEndpoint;
       fetch(`${endpoint}?id=${encodeURIComponent(id)}`)
         .then(res => res.json())
         .then(data => {

--- a/src/pages/melding.html
+++ b/src/pages/melding.html
@@ -132,6 +132,7 @@
       color: #990000;
     }
   </style>
+<script src="/apiConfo.js"></script>
 </head>
 <body>
 
@@ -176,7 +177,7 @@
     terugBtn.href = `/storing.html?id=${id}&type=${type}&lang=${lang}`;
 
     if (id && type) {
-      const endpoint = type === "eq" ? "/.netlify/functions/equipment" : "/.netlify/functions/space";
+      const endpoint = type === "eq" ? window.apiConfig.equipmentEndpoint : window.apiConfig.spaceEndpoint;
       fetch(`${endpoint}?id=${encodeURIComponent(id)}`)
         .then(res => res.json())
         .then(data => {
@@ -198,7 +199,7 @@
       const omschrijving = document.getElementById('omschrijving').value.trim();
 
       try {
-        const response = await fetch('/.netlify/functions/melding', {
+        const response = await fetch(window.apiConfig.meldingEndpoint, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({

--- a/src/pages/storing.html
+++ b/src/pages/storing.html
@@ -109,6 +109,7 @@
       transform: translateY(-2px);
     }
   </style>
+<script src="/apiConfo.js"></script>
 </head>
 <body>
 
@@ -148,8 +149,8 @@
     // Locatie/informatie bovenaan ophalen
     if (id && type) {
       const endpoint = type === "eq"
-        ? "/.netlify/functions/equipment"
-        : "/.netlify/functions/space";
+        ? window.apiConfig.equipmentEndpoint
+        : window.apiConfig.spaceEndpoint;
 
       fetch(`${endpoint}?id=${encodeURIComponent(id)}`)
         .then(res => res.json())
@@ -180,7 +181,7 @@
         isFr ? "Paramètres invalides." : "Geen geldige parameters opgegeven."
       }</div>`;
     } else {
-      fetch(`/.netlify/functions/jobs?type=${type}&id=${id}&lang=${lang}`)
+      fetch(`${window.apiConfig.jobsEndpoint}?type=${type}&id=${id}&lang=${lang}`)
         .then(res => res.json())
         .then(data => {
           if (!Array.isArray(data) || data.length === 0) {


### PR DESCRIPTION
## Summary
- add global API endpoint definitions in `public/apiConfo.js`
- reference these endpoints from all pages

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_68440416e130832fab19f8e0cbdfd20e